### PR TITLE
Change the CLA labels to not be in any way ambiguous

### DIFF
--- a/ni/github.py
+++ b/ni/github.py
@@ -10,9 +10,9 @@ from aiohttp import hdrs
 from . import abc
 
 
-LABEL_PREFIX = 'CLA: '
-CLA_OK = LABEL_PREFIX + '✓'
-NO_CLA = LABEL_PREFIX + '✗'
+LABEL_PREFIX = 'CLA '
+CLA_OK = LABEL_PREFIX + 'signed'
+NO_CLA = LABEL_PREFIX + 'not signed'
 
 NO_CLA_TEMPLATE = """Hello, and thanks for your contribution!
 

--- a/ni/test/examples/github/labels.json
+++ b/ni/test/examples/github/labels.json
@@ -5,8 +5,8 @@
     "color": "009800"
   },
   {
-    "url": "https://api.github.com/repos/Microsoft/Pyjion/labels/CLA%3A%20%E2%9C%93",
-    "name": "CLA: ✓",
+    "url": "https://api.github.com/repos/Microsoft/Pyjion/labels/CLA%20signed",
+    "name": "CLA signed",
     "color": "009800"
   }
 ]


### PR DESCRIPTION
The use of the fancy Unicode characters ran the risk of not making sense in
other cultures or not being viewable in some browser which could cause issues
with colour-blind users.

Closes #5