### PR TITLE
Respond with a 200 upon success w/ changes instead of a 204

### DIFF
--- a/ni/__main__.py
+++ b/ni/__main__.py
@@ -20,7 +20,7 @@ def handler(server, cla_records):
             # With a work queue, one could make the updating of the
             # contribution a work item and return an HTTP 202 response.
             await contribution.update(cla_status)
-            return web.Response(status=http.HTTPStatus.NO_CONTENT)
+            return web.Response(status=http.HTTPStatus.OK)
         except abc.ResponseExit as exc:
             return exc.response
         except Exception as exc:

--- a/ni/test/test_main.py
+++ b/ni/test/test_main.py
@@ -60,7 +60,7 @@ class HandlerTest(util.TestCase):
         with mock.patch('ni.__main__.ContribHost', contrib):
             responder = __main__.handler(server, cla)
             response = self.run_awaitable(responder(request))
-        self.assertEqual(response.status, 204)
+        self.assertEqual(response.status, 200)
         self.assertEqual(cla.usernames, usernames)
         self.assertEqual(contrib.status, status)
 


### PR DESCRIPTION
GitHub seems to respond faster to the MS CLA bot than this one and it might
have to do with its use of a 200 response instead of a 204.

Closes #24