### PR TITLE
Issue 20: Validate GitHub payloads using webhook secret and hashing

### DIFF
--- a/ni/abc.py
+++ b/ni/abc.py
@@ -63,6 +63,11 @@ class ServerHost(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
+    def contrib_secret_token(self):
+        """Return the authorization token for the contribution host."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
     def log_exception(self, exc):
         """Log the exception."""
 

--- a/ni/github.py
+++ b/ni/github.py
@@ -1,4 +1,6 @@
 import enum
+import hashlib
+import hmac
 import http
 from http import client
 import json
@@ -89,6 +91,12 @@ class Host(abc.ContribHost):
             raise abc.ResponseExit(
                     status=http.HTTPStatus.UNSUPPORTED_MEDIA_TYPE, text=msg)
 
+        binary_content = await request.read()
+
+        if not Host._verify_signature(server.contrib_secret_token(), binary_content,
+                                      request.headers['HTTP_X_HUB_SIGNATURE']):
+            raise abc.ResponseExit(status=http.HTTPStatus.UNAUTHORIZED)
+
         payload = await request.json()
         if 'zen' in payload:
             # A ping event; nothing to do.
@@ -117,6 +125,17 @@ class Host(abc.ContribHost):
             msg = 'unexpected response for {!r}: {}'.format(response.url,
                                                             response.status)
             raise client.HTTPException(msg)
+
+    @staticmethod
+    def _verify_signature(secret_token, data, gh_signature):
+        """
+        Compute hash using secret token and payload body and ensure it
+        matches hash from GitHub
+        """
+        mac = hmac.new(secret_token.encode(encoding='UTF-8'), msg=data,
+                       digestmod=hashlib.sha1).hexdigest()
+        signature = 'sha1={0}'.format(mac)
+        return hmac.compare_digest(signature, gh_signature)
 
     def auth_header(self):
         return {'Authorization': 'token ' + self.server.contrib_auth_token()}

--- a/ni/heroku.py
+++ b/ni/heroku.py
@@ -18,6 +18,10 @@ class Host(abc.ServerHost):
         return os.environ['GH_AUTH_TOKEN']
 
     @staticmethod
+    def contrib_secret_token():
+        return os.environ['GH_SECRET_TOKEN']
+
+    @staticmethod
     def log_exception(exc):
         """Log an exception and its traceback to stderr."""
         traceback.print_exception(type(exc), exc, exc.__traceback__,

--- a/ni/test/test_heroku.py
+++ b/ni/test/test_heroku.py
@@ -30,6 +30,11 @@ class HerokuTests(unittest.TestCase):
         os.environ['GH_AUTH_TOKEN'] = auth_token
         self.assertEqual(self.server.contrib_auth_token(), auth_token)
 
+    def test_contrib_secret_token(self):
+        secret_token = 'some_secret_token'
+        os.environ['GH_SECRET_TOKEN'] = secret_token
+        self.assertEqual(self.server.contrib_secret_token(), secret_token)
+
     def test_log_exception(self):
         # Traceback and exception should be written to stderr.
         exc_type = NotImplementedError

--- a/ni/test/util.py
+++ b/ni/test/util.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import unittest
 
 from aiohttp import web
@@ -18,9 +19,13 @@ class FakeRequest:
     def __init__(self, payload={}, content_type='application/json'):
         self.content_type = content_type
         self._payload = payload
+        self.headers = {'HTTP_X_HUB_SIGNATURE': 'x_hub'}
 
     async def json(self):
         return self._payload
+
+    async def read(self):
+        return json.dumps(self._payload).encode(encoding='UTF-8')
 
 
 class FakeResponse(web.Response):
@@ -79,6 +84,7 @@ class FakeServerHost(abc.ServerHost):
 
     port = 1234
     auth_token = 'some_auth_token'
+    secret_token = 'some_secret_token'
 
     def port(self):
         """Specify the port to bind the listening socket to."""
@@ -86,6 +92,9 @@ class FakeServerHost(abc.ServerHost):
 
     def contrib_auth_token(self):
         return self.auth_token
+
+    def contrib_secret_token(self):
+        return self.secret_token
 
     def log_exception(self, exc):
         """Log the exception."""


### PR DESCRIPTION
This is a first attempt to implement #20. I was unsure on how to update the unit tests in test_github.py to accommodate this; currently I use patching. Let me know if it  should be another way