### PR TITLE
Add info about "GitHub name" field in b.p.o account settings

### DIFF
--- a/ni/github.py
+++ b/ni/github.py
@@ -51,8 +51,9 @@ We also demand... [A SHRUBBERY!](https://www.youtube.com/watch?v=zIV4poUZAQo)
 
 NO_USERNAME_BODY = """Unfortunately we couldn't find an account corresponding \
 to your GitHub username on [bugs.python.org](http://bugs.python.org/) \
-(b.p.o) to verify you have signed the CLA. This is necessary for legal reasons \
-before we can look at your contribution. Please follow \
+(b.p.o) to verify you have signed the CLA (this might be simply due to a \
+missing "GitHub Name" entry in your b.p.o account settings). This is necessary \
+for legal reasons before we can look at your contribution. Please follow \
 [the steps outlined in the CPython devguide](https://cpython-devguide.readthedocs.io/pullrequest.html#licensing) \
 to rectify this issue.
 """


### PR DESCRIPTION
When I made a PR for the devguide, the error I got back was that no signed contributor agreement could be found for a b.p.o account matching my github username.  However, I did have a signed agreement, and in a b.p.o. account with name matching my github name. The problem was that there is a dedicated _GitHub name_ field in the b.p.o. settings, and I simply hadn't filled in that field. This proposed change refers to that _GitHub name_ field directly.