### PR TITLE
Don't check for CLA if user is in trusted list

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,14 @@ CLA).
     2. Send `application/json` (the default)
     3. Add the secret
     4. Specify events to be `pull request` only (default is `push` which is unnecessary)
+
+## Ignored Users List
+
+Users in the Ignored List will not be checked for CLA.  This can be useful if
+the user is a bot or an app. To add users to the ignore list, set the
+`CLA_IGNORED_USERNAMES` environment variable as a comma-separated list.
+
+For example, if `bot-one` and `bot-two` are to be ignored, set the environment
+variable as follows:
+
+`CLA_IGNORED_USERNAMES` = `bot-one,bot-two`

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ occurring without being given something (in the film it's the knights
 requiring a shrubbery, in real life it's lawyers requiring a signed
 CLA).
 
+## Trusted Users List
+Users in the Trusted Users List will not be checked for CLA.  This can be
+useful if the user is a bot or an app.
+
 ## Deployment
 ### Running on Heroku
 
@@ -93,6 +97,8 @@ CLA).
 2. Set the `GH_AUTH_TOKEN` environment variable to the GitHub oauth
    token to be used by the bot
 3. Set up the Heroku project to get the code for the bot
+4. Trusted users can be added to the `CLA_TRUSTED_USERS` environment variable
+   as comma-separated list.
 
 ### Adding to a GitHub repository (Python-specific instructions)
 1. Add the appropriate labels (`CLA signed` and `CLA not signed`)
@@ -102,14 +108,3 @@ CLA).
     2. Send `application/json` (the default)
     3. Add the secret
     4. Specify events to be `pull request` only (default is `push` which is unnecessary)
-
-## Ignored Users List
-
-Users in the Ignored List will not be checked for CLA.  This can be useful if
-the user is a bot or an app. To add users to the ignore list, set the
-`CLA_IGNORED_USERNAMES` environment variable as a comma-separated list.
-
-For example, if `bot-one` and `bot-two` are to be ignored, set the environment
-variable as follows:
-
-`CLA_IGNORED_USERNAMES` = `bot-one,bot-two`

--- a/ni/__main__.py
+++ b/ni/__main__.py
@@ -3,7 +3,7 @@ import asyncio
 import http
 import os
 
-from typing import Awaitable, Callable
+from typing import Awaitable, Callable, AbstractSet
 
 # ONLY third-party libraries that don't break the abstraction promise may be
 # imported.
@@ -43,7 +43,7 @@ def handler(create_client: Callable[[], aiohttp.ClientSession], server: ni_abc.S
     return respond
 
 
-def get_checked_usernames(usernames):
+def get_checked_usernames(usernames: AbstractSet[str]) -> AbstractSet[str]:
     """
     Return a list of usernames to be checked for CLA
     excluding the ignored ones
@@ -52,8 +52,8 @@ def get_checked_usernames(usernames):
     if cla_ignored_users:
         ignored_user_list = [ignored.strip().lower()
                                 for ignored in cla_ignored_users.split(",")]
-        return [username for username in usernames
-                    if username.lower() not in ignored_user_list]
+        return frozenset([username for username in usernames
+                    if username.lower() not in ignored_user_list])
 
     return usernames
 

--- a/ni/__main__.py
+++ b/ni/__main__.py
@@ -26,7 +26,7 @@ def handler(create_client: Callable[[], aiohttp.ClientSession], server: ni_abc.S
                 contribution = await ContribHost.process(server, request, client)
                 usernames = await contribution.usernames()
                 server.log("Usernames: " + str(usernames))
-                usernames = get_not_ignored_usernames(usernames)
+                usernames = get_checked_usernames(usernames)
                 cla_status = await cla_records.check(client, usernames)
                 server.log("CLA status: " + str(cla_status))
                 # With a work queue, one could make the updating of the
@@ -43,8 +43,11 @@ def handler(create_client: Callable[[], aiohttp.ClientSession], server: ni_abc.S
     return respond
 
 
-def get_not_ignored_usernames(usernames):
-    """ Return a list of usernames, excluding the ignored ones """
+def get_checked_usernames(usernames):
+    """
+    Return a list of usernames to be checked for CLA
+    excluding the ignored ones
+    """
     cla_ignored_users = os.environ.get('CLA_IGNORED_USERNAMES')
     if cla_ignored_users:
         ignored_user_list = [ignored.strip().lower()

--- a/ni/__main__.py
+++ b/ni/__main__.py
@@ -1,9 +1,8 @@
 """Implement a server to check if a contribution is covered by a CLA(s)."""
 import asyncio
 import http
-import os
 
-from typing import Awaitable, Callable, AbstractSet
+from typing import Awaitable, Callable
 
 # ONLY third-party libraries that don't break the abstraction promise may be
 # imported.
@@ -26,8 +25,8 @@ def handler(create_client: Callable[[], aiohttp.ClientSession], server: ni_abc.S
                 contribution = await ContribHost.process(server, request, client)
                 usernames = await contribution.usernames()
                 server.log("Usernames: " + str(usernames))
-                usernames = get_checked_usernames(usernames)
-                cla_status = await cla_records.check(client, usernames)
+                usernames_to_check = server.usernames_to_check(usernames)
+                cla_status = await cla_records.check(client, usernames_to_check)
                 server.log("CLA status: " + str(cla_status))
                 # With a work queue, one could make the updating of the
                 # contribution a work item and return an HTTP 202 response.
@@ -41,21 +40,6 @@ def handler(create_client: Callable[[], aiohttp.ClientSession], server: ni_abc.S
                         status=http.HTTPStatus.INTERNAL_SERVER_ERROR)
 
     return respond
-
-
-def get_checked_usernames(usernames: AbstractSet[str]) -> AbstractSet[str]:
-    """
-    Return a list of usernames to be checked for CLA
-    excluding the ignored ones
-    """
-    cla_ignored_users = os.environ.get('CLA_IGNORED_USERNAMES')
-    if cla_ignored_users:
-        ignored_user_list = [ignored.strip().lower()
-                                for ignored in cla_ignored_users.split(",")]
-        return frozenset([username for username in usernames
-                    if username.lower() not in ignored_user_list])
-
-    return usernames
 
 
 if __name__ == '__main__':

--- a/ni/__main__.py
+++ b/ni/__main__.py
@@ -47,10 +47,10 @@ def get_not_ignored_usernames(usernames):
     """ Return a list of usernames, excluding the ignored ones """
     cla_ignored_users = os.environ.get('CLA_IGNORED_USERNAMES')
     if cla_ignored_users:
-        ignored_user_list = [ignored.strip()
+        ignored_user_list = [ignored.strip().lower()
                                 for ignored in cla_ignored_users.split(",")]
         return [username for username in usernames
-                    if username not in ignored_user_list]
+                    if username.lower() not in ignored_user_list]
 
     return usernames
 

--- a/ni/__main__.py
+++ b/ni/__main__.py
@@ -25,7 +25,8 @@ def handler(create_client: Callable[[], aiohttp.ClientSession], server: ni_abc.S
                 contribution = await ContribHost.process(server, request, client)
                 usernames = await contribution.usernames()
                 server.log("Usernames: " + str(usernames))
-                usernames_to_check = server.usernames_to_check(usernames)
+                trusted_users = server.trusted_users()
+                usernames_to_check = usernames - trusted_users
                 cla_status = await cla_records.check(client, usernames_to_check)
                 server.log("CLA status: " + str(cla_status))
                 # With a work queue, one could make the updating of the

--- a/ni/__main__.py
+++ b/ni/__main__.py
@@ -1,6 +1,8 @@
 """Implement a server to check if a contribution is covered by a CLA(s)."""
 import asyncio
 import http
+import os
+
 from typing import Awaitable, Callable
 
 # ONLY third-party libraries that don't break the abstraction promise may be
@@ -24,6 +26,9 @@ def handler(create_client: Callable[[], aiohttp.ClientSession], server: ni_abc.S
                 contribution = await ContribHost.process(server, request, client)
                 usernames = await contribution.usernames()
                 server.log("Usernames: " + str(usernames))
+                usernames = [username
+                                for username in usernames
+                                    if username not in os.environ.get('WHITELISTED_USERS')]
                 cla_status = await cla_records.check(client, usernames)
                 server.log("CLA status: " + str(cla_status))
                 # With a work queue, one could make the updating of the

--- a/ni/abc.py
+++ b/ni/abc.py
@@ -1,5 +1,4 @@
 import abc
-import asyncio
 import enum
 import http
 from typing import AbstractSet, Any, Optional, Tuple
@@ -58,6 +57,23 @@ class ServerHost(abc.ABC):
     @abc.abstractmethod
     def log(self, message: str) -> None:
         """Log the message."""
+
+    @abc.abstractmethod
+    def trusted_users(self) -> AbstractSet[str]:
+        """Return a list of trusted users.
+
+        Trusted users will not be checked for CLA.
+        """
+        return frozenset()
+
+    @abc.abstractmethod
+    def usernames_to_check(self,
+                           all_usernames:AbstractSet[str]) -> AbstractSet[str]:
+        """Return a list of users to be checked for CLA.
+
+        Exclude users who are in the trusted list.
+        """
+        raise NotImplementedError
 
 
 class ContribHost(abc.ABC):

--- a/ni/abc.py
+++ b/ni/abc.py
@@ -66,15 +66,6 @@ class ServerHost(abc.ABC):
         """
         return frozenset()
 
-    @abc.abstractmethod
-    def usernames_to_check(self,
-                           all_usernames:AbstractSet[str]) -> AbstractSet[str]:
-        """Return a list of users to be checked for CLA.
-
-        Exclude users who are in the trusted list.
-        """
-        raise NotImplementedError
-
 
 class ContribHost(abc.ABC):
 

--- a/ni/heroku.py
+++ b/ni/heroku.py
@@ -40,16 +40,7 @@ class Host(ni_abc.ServerHost):
 
         Trusted users will not be checked for CLA.
         """
-        cla_trusted_users = os.environ.get('CLA_TRUSTED_USERS')
-        if cla_trusted_users:
-            return frozenset([trusted.strip().lower()
-                    for trusted in cla_trusted_users.split(",")])
-        return frozenset()
+        cla_trusted_users = os.environ.get('CLA_TRUSTED_USERS', '')
 
-    def usernames_to_check(self,
-                           all_usernames: AbstractSet[str]) -> AbstractSet[str]:
-        """Return a list of users to be checked for CLA.
-
-        Exclude users who are in the trusted list.
-        """
-        return all_usernames - self.trusted_users()
+        return frozenset([trusted.strip().lower()
+                for trusted in cla_trusted_users.split(",")])

--- a/ni/heroku.py
+++ b/ni/heroku.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import traceback
-from typing import Optional
+from typing import AbstractSet, Optional
 
 from . import abc as ni_abc
 
@@ -34,3 +34,22 @@ class Host(ni_abc.ServerHost):
     def log(self, message: str) -> None:
         """Log a message to stderr."""
         print(message, file=sys.stderr)
+
+    def trusted_users(self) -> AbstractSet[str]:
+        """Return a list of trusted users.
+
+        Trusted users will not be checked for CLA.
+        """
+        cla_trusted_users = os.environ.get('CLA_TRUSTED_USERS')
+        if cla_trusted_users:
+            return frozenset([trusted.strip().lower()
+                    for trusted in cla_trusted_users.split(",")])
+        return frozenset()
+
+    def usernames_to_check(self,
+                           all_usernames: AbstractSet[str]) -> AbstractSet[str]:
+        """Return a list of users to be checked for CLA.
+
+        Exclude users who are in the trusted list.
+        """
+        return all_usernames - self.trusted_users()

--- a/ni/test/test_heroku.py
+++ b/ni/test/test_heroku.py
@@ -3,7 +3,8 @@ import io
 import os
 import random
 import unittest
-import unittest.mock as mock
+
+from unittest import mock
 
 from .. import heroku
 
@@ -65,39 +66,12 @@ class HerokuTests(unittest.TestCase):
             self.server.log(message)
         self.assertEqual(stderr.getvalue(), message + "\n")
 
+    @mock.patch.dict(os.environ, {'CLA_TRUSTED_USERS': "miss-islington,bedevere-bot"})
     def test_trusted_users(self):
-        trusted_users = "miss-islington,bedevere-bot,the-knights-who-say-ni"
-        os.environ["CLA_TRUSTED_USERS"] = trusted_users
         self.assertEqual(self.server.trusted_users(),
-                         frozenset(["miss-islington",
-                                    "bedevere-bot",
-                                    "the-knights-who-say-ni"])
+                         frozenset(["miss-islington", "bedevere-bot"])
                          )
 
+    @mock.patch.dict(os.environ, {'CLA_TRUSTED_USERS': ""})
     def test_no_trusted_users(self):
-        usernames = frozenset(['miss-islington', 'bedevere-bot'])
-        self.assertEqual(self.server.usernames_to_check(usernames), usernames)
-
-    @mock.patch.dict(os.environ, {'CLA_TRUSTED_USERS': 'bedevere-bot'})
-    def test_not_comma_separated_ignore_list(self):
-        usernames = frozenset(['miss-islington', 'bedevere-bot'])
-        self.assertEqual(self.server.usernames_to_check(usernames),
-                         frozenset(['miss-islington']))
-
-    @mock.patch.dict(os.environ, {'CLA_TRUSTED_USERS': 'bedevere-bot,miss-islington'})
-    def test_comma_separated_ignore_list(self):
-        usernames = frozenset(['brettcannon', 'bedevere-bot', 'miss-islington'])
-        self.assertEqual(self.server.usernames_to_check(usernames),
-                         frozenset(['brettcannon']))
-
-    @mock.patch.dict(os.environ, {'CLA_TRUSTED_USERS': 'bedevere-bot, miss-islington'})
-    def test_comma_separated_ignore_list_with_spaces(self):
-        usernames = frozenset(['brettcannon', 'bedevere-bot', 'miss-islington'])
-        self.assertEqual(self.server.usernames_to_check(usernames),
-                         frozenset(['brettcannon']))
-
-    @mock.patch.dict(os.environ, {'CLA_TRUSTED_USERS': 'bedevere-bot, Miss-Islington'})
-    def test_ignore_list_ignore_case(self):
-        usernames = frozenset(['brettcannon', 'bedevere-bot', 'miss-islington'])
-        self.assertEqual(self.server.usernames_to_check(usernames),
-                         frozenset(['brettcannon']))
+        self.assertEqual(self.server.trusted_users(), frozenset({''}))

--- a/ni/test/test_heroku.py
+++ b/ni/test/test_heroku.py
@@ -3,6 +3,7 @@ import io
 import os
 import random
 import unittest
+import unittest.mock as mock
 
 from .. import heroku
 
@@ -63,3 +64,40 @@ class HerokuTests(unittest.TestCase):
         with contextlib.redirect_stderr(stderr):
             self.server.log(message)
         self.assertEqual(stderr.getvalue(), message + "\n")
+
+    def test_trusted_users(self):
+        trusted_users = "miss-islington,bedevere-bot,the-knights-who-say-ni"
+        os.environ["CLA_TRUSTED_USERS"] = trusted_users
+        self.assertEqual(self.server.trusted_users(),
+                         frozenset(["miss-islington",
+                                    "bedevere-bot",
+                                    "the-knights-who-say-ni"])
+                         )
+
+    def test_no_trusted_users(self):
+        usernames = frozenset(['miss-islington', 'bedevere-bot'])
+        self.assertEqual(self.server.usernames_to_check(usernames), usernames)
+
+    @mock.patch.dict(os.environ, {'CLA_TRUSTED_USERS': 'bedevere-bot'})
+    def test_not_comma_separated_ignore_list(self):
+        usernames = frozenset(['miss-islington', 'bedevere-bot'])
+        self.assertEqual(self.server.usernames_to_check(usernames),
+                         frozenset(['miss-islington']))
+
+    @mock.patch.dict(os.environ, {'CLA_TRUSTED_USERS': 'bedevere-bot,miss-islington'})
+    def test_comma_separated_ignore_list(self):
+        usernames = frozenset(['brettcannon', 'bedevere-bot', 'miss-islington'])
+        self.assertEqual(self.server.usernames_to_check(usernames),
+                         frozenset(['brettcannon']))
+
+    @mock.patch.dict(os.environ, {'CLA_TRUSTED_USERS': 'bedevere-bot, miss-islington'})
+    def test_comma_separated_ignore_list_with_spaces(self):
+        usernames = frozenset(['brettcannon', 'bedevere-bot', 'miss-islington'])
+        self.assertEqual(self.server.usernames_to_check(usernames),
+                         frozenset(['brettcannon']))
+
+    @mock.patch.dict(os.environ, {'CLA_TRUSTED_USERS': 'bedevere-bot, Miss-Islington'})
+    def test_ignore_list_ignore_case(self):
+        usernames = frozenset(['brettcannon', 'bedevere-bot', 'miss-islington'])
+        self.assertEqual(self.server.usernames_to_check(usernames),
+                         frozenset(['brettcannon']))

--- a/ni/test/test_main.py
+++ b/ni/test/test_main.py
@@ -4,7 +4,7 @@ import os
 import unittest.mock as mock
 
 from .. import __main__
-from ..__main__ import get_not_ignored_usernames
+from ..__main__ import get_checked_usernames
 from .. import abc as ni_abc
 from .. import github
 from . import util
@@ -126,25 +126,25 @@ class GetNotIgnoredUsernamesTest(util.TestCase):
 
     def test_no_ignored_list(self):
         usernames = ['brettcannon', 'mariatta']
-        self.assertEqual(get_not_ignored_usernames(usernames), usernames)
+        self.assertEqual(get_checked_usernames(usernames), usernames)
 
     @mock.patch.dict(os.environ, {'CLA_IGNORED_USERNAMES': 'bedevere-bot'})
     def test_not_comma_separated_ignore_list(self):
         usernames = ['brettcannon', 'bedevere-bot']
-        self.assertEqual(get_not_ignored_usernames(usernames), ['brettcannon'])
+        self.assertEqual(get_checked_usernames(usernames), ['brettcannon'])
 
     @mock.patch.dict(os.environ, {'CLA_IGNORED_USERNAMES': 'bedevere-bot,miss-islington'})
     def test_comma_separated_ignore_list(self):
         usernames = ['brettcannon', 'bedevere-bot', 'miss-islington']
-        self.assertEqual(get_not_ignored_usernames(usernames), ['brettcannon'])
+        self.assertEqual(get_checked_usernames(usernames), ['brettcannon'])
 
     @mock.patch.dict(os.environ, {'CLA_IGNORED_USERNAMES': 'bedevere-bot, miss-islington'})
     def test_comma_separated_ignore_list_with_spaces(self):
         usernames = ['brettcannon', 'bedevere-bot', 'miss-islington']
-        self.assertEqual(get_not_ignored_usernames(usernames), ['brettcannon'])
+        self.assertEqual(get_checked_usernames(usernames), ['brettcannon'])
 
     @mock.patch.dict(os.environ,
                      {'CLA_IGNORED_USERNAMES': 'bedevere-bot, Miss-Islington'})
     def test_ignore_list_ignore_case(self):
         usernames = ['brettcannon', 'bedevere-bot', 'miss-islington']
-        self.assertEqual(get_not_ignored_usernames(usernames), ['brettcannon'])
+        self.assertEqual(get_checked_usernames(usernames), ['brettcannon'])

--- a/ni/test/test_main.py
+++ b/ni/test/test_main.py
@@ -125,26 +125,30 @@ class HandlerTest(util.TestCase):
 class GetNotIgnoredUsernamesTest(util.TestCase):
 
     def test_no_ignored_list(self):
-        usernames = ['brettcannon', 'mariatta']
+        usernames = frozenset(['brettcannon', 'mariatta'])
         self.assertEqual(get_checked_usernames(usernames), usernames)
 
     @mock.patch.dict(os.environ, {'CLA_IGNORED_USERNAMES': 'bedevere-bot'})
     def test_not_comma_separated_ignore_list(self):
-        usernames = ['brettcannon', 'bedevere-bot']
-        self.assertEqual(get_checked_usernames(usernames), ['brettcannon'])
+        usernames = frozenset(['brettcannon', 'bedevere-bot'])
+        self.assertEqual(get_checked_usernames(usernames),
+                         frozenset(['brettcannon']))
 
     @mock.patch.dict(os.environ, {'CLA_IGNORED_USERNAMES': 'bedevere-bot,miss-islington'})
     def test_comma_separated_ignore_list(self):
-        usernames = ['brettcannon', 'bedevere-bot', 'miss-islington']
-        self.assertEqual(get_checked_usernames(usernames), ['brettcannon'])
+        usernames = frozenset(['brettcannon', 'bedevere-bot', 'miss-islington'])
+        self.assertEqual(get_checked_usernames(usernames),
+                         frozenset(['brettcannon']))
 
     @mock.patch.dict(os.environ, {'CLA_IGNORED_USERNAMES': 'bedevere-bot, miss-islington'})
     def test_comma_separated_ignore_list_with_spaces(self):
-        usernames = ['brettcannon', 'bedevere-bot', 'miss-islington']
-        self.assertEqual(get_checked_usernames(usernames), ['brettcannon'])
+        usernames = frozenset(['brettcannon', 'bedevere-bot', 'miss-islington'])
+        self.assertEqual(get_checked_usernames(usernames),
+                         frozenset(['brettcannon']))
 
     @mock.patch.dict(os.environ,
                      {'CLA_IGNORED_USERNAMES': 'bedevere-bot, Miss-Islington'})
     def test_ignore_list_ignore_case(self):
-        usernames = ['brettcannon', 'bedevere-bot', 'miss-islington']
-        self.assertEqual(get_checked_usernames(usernames), ['brettcannon'])
+        usernames = frozenset(['brettcannon', 'bedevere-bot', 'miss-islington'])
+        self.assertEqual(get_checked_usernames(usernames),
+                         frozenset(['brettcannon']))

--- a/ni/test/test_main.py
+++ b/ni/test/test_main.py
@@ -142,3 +142,9 @@ class GetNotIgnoredUsernamesTest(util.TestCase):
     def test_comma_separated_ignore_list_with_spaces(self):
         usernames = ['brettcannon', 'bedevere-bot', 'miss-islington']
         self.assertEqual(get_not_ignored_usernames(usernames), ['brettcannon'])
+
+    @mock.patch.dict(os.environ,
+                     {'CLA_IGNORED_USERNAMES': 'bedevere-bot, Miss-Islington'})
+    def test_ignore_list_ignore_case(self):
+        usernames = ['brettcannon', 'bedevere-bot', 'miss-islington']
+        self.assertEqual(get_not_ignored_usernames(usernames), ['brettcannon'])

--- a/ni/test/util.py
+++ b/ni/test/util.py
@@ -97,6 +97,7 @@ class FakeServerHost(ni_abc.ServerHost):
     auth_token = 'some_auth_token'
     secret = None
     user_agent_name = 'Testing-Agent'
+    trusted_usernames = ''
 
     def port(self):
         """Specify the port to bind the listening socket to."""
@@ -120,6 +121,16 @@ class FakeServerHost(ni_abc.ServerHost):
             self.logged.append(message)
         except AttributeError:
             self.logged = [message]
+
+    def trusted_users(self):
+        return frozenset(self.trusted_usernames)
+
+    def usernames_to_check(self, all_usernames):
+        """Return a list of users to be checked for CLA.
+
+        Exclude users who are in the trusted list.
+        """
+        return all_usernames - self.trusted_users()
 
 
 class TestCase(unittest.TestCase):

--- a/ni/test/util.py
+++ b/ni/test/util.py
@@ -123,14 +123,8 @@ class FakeServerHost(ni_abc.ServerHost):
             self.logged = [message]
 
     def trusted_users(self):
-        return frozenset(self.trusted_usernames)
-
-    def usernames_to_check(self, all_usernames):
-        """Return a list of users to be checked for CLA.
-
-        Exclude users who are in the trusted list.
-        """
-        return all_usernames - self.trusted_users()
+        return frozenset(frozenset([trusted.strip().lower()
+                for trusted in self.trusted_usernames.split(",")]))
 
 
 class TestCase(unittest.TestCase):


### PR DESCRIPTION
Users to be ignored are to be stored as a comma separated env variable:
`CLA_TRUSTED_USERS`

Closes https://github.com/python/the-knights-who-say-ni/issues/48