### PR TITLE
Set Heroku's runtime environment to Python 3.6.4

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.1
+python-3.6.4


### PR DESCRIPTION
Previously it was set to 3.6.1