### PR TITLE
Clarify wording around CLA not being received

### DIFF
--- a/ni/github.py
+++ b/ni/github.py
@@ -39,11 +39,14 @@ You can [check yourself](https://check-python-cla.herokuapp.com/) to see if the 
 Thanks again for your contribution, we look forward to reviewing it!
 """
 
-NO_CLA_BODY = """Unfortunately our records indicate you have not signed the CLA. \
+NO_CLA_BODY = """Our records indicate we have not received your CLA. \
 For legal reasons we need you to sign this before we can look at your \
 contribution. Please follow \
 [the steps outlined in the CPython devguide](https://devguide.python.org/pullrequest/#licensing) \
 to rectify this issue.
+
+If you have recently signed the CLA, please wait at least one business day
+before our records are updated.
 """
 
 NO_CLA_BODY_EASTEREGG = NO_CLA_BODY + """


### PR DESCRIPTION
The need to wait at least one *business* day is explained in the devguide, but it's not too prominent there.
The Knights' current wording makes it sound like the ball is in the contributor's court, but it's not. If someone signs the CLA on a Saturday, they actually need to wait for the whole weekend
before the contribution can be reviewed.

- Change "you have not signed the CLA" to "we have not received your CLA".

- Add a note on waiting for a businnes day directly to the commit template.

Example of the confusion this is trying to fix: https://github.com/python/peps/pull/820