### PR TITLE
Add test that bot-user is acceptable trusted user.

### DIFF
--- a/ni/test/test_heroku.py
+++ b/ni/test/test_heroku.py
@@ -66,10 +66,10 @@ class HerokuTests(unittest.TestCase):
             self.server.log(message)
         self.assertEqual(stderr.getvalue(), message + "\n")
 
-    @mock.patch.dict(os.environ, {'CLA_TRUSTED_USERS': "miss-islington,bedevere-bot"})
+    @mock.patch.dict(os.environ, {'CLA_TRUSTED_USERS': "miss-islington,bedevere-bot,blurb-it[bot]"})
     def test_trusted_users(self):
         self.assertEqual(self.server.trusted_users(),
-                         frozenset(["miss-islington", "bedevere-bot"])
+                         frozenset(["miss-islington", "bedevere-bot", "blurb-it[bot]"])
                          )
 
     @mock.patch.dict(os.environ, {'CLA_TRUSTED_USERS': ""})


### PR DESCRIPTION
GitHub Apps will have `[bot]` in the username, e.g. blurb-it[bot].

Adjusted the test case when retrieving trusted user list.

Once passed and deployed:

- [ ] add blurb-it[bot] to trusted users in Heroku.