### PR TITLE
mypy: check untyped tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ install:
   - python3 -m pip install -r requirements.txt
 script:
   - python3 -m coverage run --branch -m unittest discover -t . -s ni/test/
-  - ./mypy.sh
+  - python3 -m mypy ni
 after_success:
   - codecov

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,13 @@
+[mypy]
+# Add in `disallow_untyped_calls = true` once aiohttp is fully typed.
+
+# the tests do not have full type coverage
+check_untyped_defs = true
+disallow_untyped_defs = true
+ignore_missing_imports = true
+strict_optional = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+
+[mypy-ni.test.*]
+disallow_untyped_defs = false

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,7 @@
 [mypy]
 # Add in `disallow_untyped_calls = true` once aiohttp is fully typed.
 
-# the tests do not have full type coverage
+# The tests do not have full type coverage.
 check_untyped_defs = true
 disallow_untyped_defs = true
 ignore_missing_imports = true
@@ -10,4 +10,5 @@ warn_redundant_casts = true
 warn_unused_ignores = true
 
 [mypy-ni.test.*]
+# The tests do not have full type coverage.
 disallow_untyped_defs = false

--- a/mypy.sh
+++ b/mypy.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-# Add in `--disallow-untyped-calls` once aiohttp is fully typed.
-python3 -m mypy --strict-optional --ignore-missing-imports --warn-unused-ignores --warn-redundant-casts --disallow-untyped-defs ni/*.py

--- a/ni/github.py
+++ b/ni/github.py
@@ -1,15 +1,11 @@
 import asyncio
 import enum
 import http
-from http import client
-import json
-import operator
 import random
 from typing import AbstractSet, Any, Dict, Optional
-from urllib import parse
 
 import aiohttp
-from aiohttp import hdrs, web
+from aiohttp import web
 from gidgethub.aiohttp import GitHubAPI
 from gidgethub import sansio
 import uritemplate

--- a/ni/test/test_bpo.py
+++ b/ni/test/test_bpo.py
@@ -17,14 +17,14 @@ class OfflineTests(util.TestCase):
         failed_response = util.FakeResponse(status=404)
         fake_session = util.FakeSession(response=failed_response)
         with self.assertRaises(client.HTTPException):
-            self.run_awaitable(host.check(fake_session, ['brettcannon']))
+            self.run_awaitable(host.check(fake_session, {'brettcannon'}))
 
     def test_filter_extraneous_data(self):
         host = bpo.Host(util.FakeServerHost())
         response_data = {'web-flow': None, 'brettcannon': True}
         fake_response = util.FakeResponse(data=json.dumps(response_data))
         fake_session = util.FakeSession(response=fake_response)
-        result = self.run_awaitable(host.check(fake_session, ['brettcannon']))
+        result = self.run_awaitable(host.check(fake_session, {'brettcannon'}))
         self.assertEqual(result, ni_abc.Status.signed)
 
     def test_missing_data(self):
@@ -33,7 +33,7 @@ class OfflineTests(util.TestCase):
         fake_response = util.FakeResponse(data=json.dumps(response_data))
         fake_session = util.FakeSession(response=fake_response)
         with self.assertRaises(ValueError):
-            self.run_awaitable(host.check(fake_session, ['brettcannon']))
+            self.run_awaitable(host.check(fake_session, {'brettcannon'}))
 
     def test_bad_data(self):
         host = bpo.Host(util.FakeServerHost())
@@ -41,7 +41,7 @@ class OfflineTests(util.TestCase):
         fake_response = util.FakeResponse(data=json.dumps(response_data))
         fake_session = util.FakeSession(response=fake_response)
         with self.assertRaises(TypeError):
-            self.run_awaitable(host.check(fake_session, ['brettcannon']))
+            self.run_awaitable(host.check(fake_session, {'brettcannon'}))
 
 
 class SessionOnDemand:

--- a/ni/test/test_main.py
+++ b/ni/test/test_main.py
@@ -1,5 +1,6 @@
 import http
 import unittest.mock as mock
+from typing import FrozenSet
 
 from .. import __main__
 from .. import abc as ni_abc
@@ -91,7 +92,6 @@ class HandlerTest(util.TestCase):
         self.assertEqual(server.logged_exc, exc)
 
     def test_contrib_secret_given(self):
-        usernames = ['brettcannon']
         status = ni_abc.Status.signed
         server = util.FakeServerHost()
         server.secret = "secret"
@@ -105,7 +105,6 @@ class HandlerTest(util.TestCase):
         self.assertEqual(response.status, 500)
 
     def test_contrib_secret_missing(self):
-        usernames = ['brettcannon']
         status = ni_abc.Status.signed
         server = util.FakeServerHost()
         cla = FakeCLAHost(status)
@@ -192,7 +191,7 @@ class HandlerTest(util.TestCase):
         self.assertEqual(cla.usernames, frozenset(['brettcannon']))
 
     def test_no_usernames(self):
-        usernames = []
+        usernames: FrozenSet[str] = frozenset()
         status = ni_abc.Status.not_signed
         server = util.FakeServerHost()
         server.trusted_usernames = 'bedevere-bot, miss-islington'
@@ -203,7 +202,7 @@ class HandlerTest(util.TestCase):
             responder = __main__.handler(util.FakeSession, server, cla)
             response = self.run_awaitable(responder(request))
         self.assertEqual(response.status, 200)
-        self.assertEqual(cla.usernames, frozenset([]))
+        self.assertEqual(cla.usernames, frozenset())
         self.assertEqual(contrib.status, status)
 
     def test_all_trusted_users(self):


### PR DESCRIPTION
This aims to make #81 easier or not-required, notably mypy is now type-checking tests without the need to annotate them.