### PR TITLE
Mention which users have not signed the CLA

### DIFF
--- a/ni/__main__.py
+++ b/ni/__main__.py
@@ -31,11 +31,11 @@ def handler(create_client: Callable[[], aiohttp.ClientSession], server: ni_abc.S
                 server.log("Usernames: " + str(usernames))
                 trusted_users = server.trusted_users()
                 usernames_to_check = usernames - trusted_users
-                cla_status = await cla_records.check(client, usernames_to_check)
-                server.log("CLA status: " + str(cla_status))
+                problems = await cla_records.problems(client, usernames_to_check)
+                server.log("CLA problems: " + str(problems))
                 # With a work queue, one could make the updating of the
                 # contribution a work item and return an HTTP 202 response.
-                await contribution.update(cla_status)
+                await contribution.update(problems)
                 return web.Response(status=http.HTTPStatus.OK)
             except ni_abc.ResponseExit as exc:
                 return exc.response

--- a/ni/abc.py
+++ b/ni/abc.py
@@ -1,7 +1,7 @@
 import abc
 import enum
 import http
-from typing import AbstractSet, Any, Optional, Tuple
+from typing import AbstractSet, Any, Mapping, Optional, Tuple
 
 # ONLY third-party libraries which won't break the abstraction promise may be
 # imported.
@@ -91,7 +91,7 @@ class ContribHost(abc.ABC):
         return frozenset()  # pragma: no cover
 
     @abc.abstractmethod
-    async def update(self, status: Status) -> None:
+    async def update(self, problems: Mapping[Status, AbstractSet[str]]) -> None:
         """Update the contribution with the status of CLA coverage."""
 
 
@@ -101,10 +101,9 @@ class CLAHost(abc.ABC):
 
     @abc.abstractmethod
     async def check(self, client: aiohttp.ClientSession,
-                    usernames: AbstractSet[str]) -> Status:
-        """Check if all of the specified usernames have signed the CLA."""
-        # While it would technically share more specific information if a
-        # mapping of {username: Status} was returned, the vast majority of
-        # cases will be for a single user and thus not worth the added
-        # complexity to need to worry about it.
-        return Status.username_not_found  # pragma: no cover
+                    usernames: AbstractSet[str]) -> Mapping[Status, AbstractSet[str]]:
+        """Check if all of the specified usernames have signed the CLA.
+
+        Return a Mapping of problems and the associated list of usernames.
+        """
+        return {Status.username_not_found: {'username'}}  # pragma: no cover

--- a/ni/abc.py
+++ b/ni/abc.py
@@ -106,4 +106,4 @@ class CLAHost(abc.ABC):
 
         Return a Mapping of problems and the associated list of usernames.
         """
-        return {Status.username_not_found: {'username'}}  # pragma: no cover
+        raise NotImplementedError

--- a/ni/abc.py
+++ b/ni/abc.py
@@ -100,7 +100,7 @@ class CLAHost(abc.ABC):
     """Abstract base class for the CLA records platform."""
 
     @abc.abstractmethod
-    async def check(self, client: aiohttp.ClientSession,
+    async def problems(self, client: aiohttp.ClientSession,
                     usernames: AbstractSet[str]) -> Mapping[Status, AbstractSet[str]]:
         """Check if all of the specified usernames have signed the CLA.
 

--- a/ni/bpo.py
+++ b/ni/bpo.py
@@ -1,4 +1,3 @@
-from collections import defaultdict
 from http import client
 import json
 from typing import AbstractSet, Mapping, Set
@@ -40,10 +39,9 @@ class Host(ni_abc.CLAHost):
             None: ni_abc.Status.username_not_found,
             False: ni_abc.Status.not_signed,
         }
-        problems: Mapping[ni_abc.Status, Set[str]] = defaultdict(set)
+        problems: Mapping[ni_abc.Status, Set[str]] = {}
         for username, result in results.items():
-            if result:
-                continue
-            problems[failures[result]].add(username)
+            if result in failures:
+                problems.setdefault(failures[result], set()).add(username)
 
         return problems

--- a/ni/bpo.py
+++ b/ni/bpo.py
@@ -14,7 +14,7 @@ class Host(ni_abc.CLAHost):
     def __init__(self, server: ni_abc.ServerHost) -> None:
         self.server = server
 
-    async def check(self, aio_client: aiohttp.ClientSession,
+    async def problems(self, aio_client: aiohttp.ClientSession,
                     usernames: AbstractSet[str]) -> Mapping[ni_abc.Status, AbstractSet[str]]:
         base_url = "https://bugs.python.org/user?@template=clacheck&github_names="
         url = base_url + ','.join(usernames)

--- a/ni/bpo.py
+++ b/ni/bpo.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from http import client
 import json
-from typing import AbstractSet, Mapping
+from typing import AbstractSet, Mapping, Set
 
 import aiohttp
 
@@ -40,7 +40,7 @@ class Host(ni_abc.CLAHost):
             None: ni_abc.Status.username_not_found,
             False: ni_abc.Status.not_signed,
         }
-        problems = defaultdict(set)
+        problems: Mapping[ni_abc.Status, Set[str]] = defaultdict(set)
         for username, result in results.items():
             if result:
                 continue

--- a/ni/bpo.py
+++ b/ni/bpo.py
@@ -1,6 +1,6 @@
 from http import client
 import json
-from typing import AbstractSet, Mapping, Set
+from typing import AbstractSet, Mapping, MutableMapping, Set
 
 import aiohttp
 
@@ -39,7 +39,7 @@ class Host(ni_abc.CLAHost):
             None: ni_abc.Status.username_not_found,
             False: ni_abc.Status.not_signed,
         }
-        problems: Mapping[ni_abc.Status, Set[str]] = {}
+        problems: MutableMapping[ni_abc.Status, Set[str]] = {}
         for username, result in results.items():
             if result in failures:
                 problems.setdefault(failures[result], set()).add(username)

--- a/ni/github.py
+++ b/ni/github.py
@@ -218,7 +218,7 @@ class Host(ni_abc.ContribHost):
             return None
 
         comments_url = self.request['pull_request']['comments_url']
-        problem_messages = defaultdict(str)
+        problem_messages: Dict[str, str] = defaultdict(str)
         for status, usernames in problems.items():
             problem_messages[status.name] = self._problem_message_template(
                 status

--- a/ni/github.py
+++ b/ni/github.py
@@ -24,8 +24,8 @@ EASTEREGG_PROBABILITY = 0.01
 
 NO_CLA_TEMPLATE = """Hello, and thanks for your contribution!
 
-I'm a bot set up to make sure that the project can legally accept your \
-contribution by verifying you have signed the \
+I'm a bot set up to make sure that the project can legally accept this \
+contribution by verifying everyone involved has signed the \
 [PSF contributor agreement](https://www.python.org/psf/contrib/contrib-form/) \
 (CLA).
 
@@ -35,19 +35,22 @@ contribution by verifying you have signed the \
 
 You can [check yourself](https://check-python-cla.herokuapp.com/) to see if the CLA has been received.
 
-Thanks again for your contribution, we look forward to reviewing it!
+Thanks again for the contribution, we look forward to reviewing it!
 """
 
-NO_CLA_BODY = """Our records indicate we have not received your CLA. \
-For legal reasons we need you to sign this before we can look at your \
+NO_CLA_BODY = """## CLA Missing
+
+Our records indicate the following people have not signed the CLA:
+
+{}
+
+For legal reasons we need all the people listed to sign the CLA before we can look at your \
 contribution. Please follow \
 [the steps outlined in the CPython devguide](https://devguide.python.org/pullrequest/#licensing) \
 to rectify this issue.
 
 If you have recently signed the CLA, please wait at least one business day
 before our records are updated.
-
-Users: {}
 """
 
 NO_CLA_BODY_EASTEREGG = NO_CLA_BODY + """
@@ -55,15 +58,18 @@ NO_CLA_BODY_EASTEREGG = NO_CLA_BODY + """
 We also demand... [A SHRUBBERY!](https://www.youtube.com/watch?v=zIV4poUZAQo)
 """
 
-NO_USERNAME_BODY = """Unfortunately we couldn't find an account corresponding \
-to your GitHub username on [bugs.python.org](https://bugs.python.org/) \
-(b.p.o) to verify you have signed the CLA (this might be simply due to a \
-missing "GitHub Name" entry in your b.p.o account settings). This is necessary \
-for legal reasons before we can look at your contribution. Please follow \
+NO_USERNAME_BODY = """## Recognized GitHub username
+
+We couldn't find a [bugs.python.org](https://bugs.python.org/) (b.p.o) account corresponding \
+to the following GitHub usernames:
+
+{}
+
+This might be simply due to a missing "GitHub Name" entry in one's b.p.o account settings. \
+This is necessary \
+for legal reasons before we can look at this contribution. Please follow \
 [the steps outlined in the CPython devguide](https://devguide.python.org/pullrequest/#licensing) \
 to rectify this issue.
-
-Users: {}
 """
 
 

--- a/ni/test/test_main.py
+++ b/ni/test/test_main.py
@@ -1,6 +1,6 @@
 import http
 import unittest.mock as mock
-from typing import FrozenSet
+from typing import AbstractSet, FrozenSet, Mapping
 
 from .. import __main__
 from .. import abc as ni_abc
@@ -53,7 +53,7 @@ class HandlerTest(util.TestCase):
     def test_response(self):
         # Success case.
         usernames = ['brettcannon']
-        problems = {}
+        problems: Mapping[ni_abc.Status, AbstractSet[str]] = {}
         server = util.FakeServerHost()
         cla = FakeCLAHost(problems)
         contrib = FakeContribHost(usernames)
@@ -92,7 +92,7 @@ class HandlerTest(util.TestCase):
         self.assertEqual(server.logged_exc, exc)
 
     def test_contrib_secret_given(self):
-        problems = {}
+        problems: Mapping[ni_abc.Status, AbstractSet[str]] = {}
         server = util.FakeServerHost()
         server.secret = "secret"
         cla = FakeCLAHost(problems)
@@ -105,7 +105,7 @@ class HandlerTest(util.TestCase):
         self.assertEqual(response.status, 500)
 
     def test_contrib_secret_missing(self):
-        problems = {}
+        problems: Mapping[ni_abc.Status, AbstractSet[str]] = {}
         server = util.FakeServerHost()
         cla = FakeCLAHost(problems)
         contrib = github.Host
@@ -119,7 +119,7 @@ class HandlerTest(util.TestCase):
 
     def test_no_trusted_users(self):
         usernames = ['miss-islington', 'bedevere-bot']
-        problems = {}
+        problems: Mapping[ni_abc.Status, AbstractSet[str]] = {}
         server = util.FakeServerHost()
         server.trusted_usernames = ''
         cla = FakeCLAHost(problems)
@@ -134,7 +134,7 @@ class HandlerTest(util.TestCase):
 
     def test_not_comma_separated_trusted_users(self):
         usernames = ['miss-islington', 'bedevere-bot']
-        problems = {}
+        problems: Mapping[ni_abc.Status, AbstractSet[str]] = {}
         server = util.FakeServerHost()
         server.trusted_usernames = 'bedevere-bot'
         cla = FakeCLAHost(problems)
@@ -148,7 +148,7 @@ class HandlerTest(util.TestCase):
 
     def test_comma_separated_trusted_users(self):
         usernames = ['brettcannon', 'miss-islington', 'bedevere-bot']
-        problems = {}
+        problems: Mapping[ni_abc.Status, AbstractSet[str]] = {}
         server = util.FakeServerHost()
         server.trusted_usernames = 'bedevere-bot,miss-islington'
         cla = FakeCLAHost(problems)
@@ -163,7 +163,7 @@ class HandlerTest(util.TestCase):
     def test_comma_separated_trusted_users_with_spaces(self):
         usernames = ['brettcannon', 'miss-islington', 'bedevere-bot']
 
-        problems = {}
+        problems: Mapping[ni_abc.Status, AbstractSet[str]] = {}
         server = util.FakeServerHost()
         server.trusted_usernames = 'bedevere-bot, miss-islington'
         cla = FakeCLAHost(problems)
@@ -178,7 +178,7 @@ class HandlerTest(util.TestCase):
     def test_trusted_users_ignored_case(self):
         usernames = ['brettcannon', 'miss-islington', 'bedevere-bot']
 
-        problems = {}
+        problems: Mapping[ni_abc.Status, AbstractSet[str]] = {}
         server = util.FakeServerHost()
         server.trusted_usernames = 'bedevere-bot, Miss-Islington'
         cla = FakeCLAHost(problems)
@@ -207,7 +207,7 @@ class HandlerTest(util.TestCase):
 
     def test_all_trusted_users(self):
         usernames = ['bedevere-bot', 'miss-islington']
-        problems = {}
+        problems: Mapping[ni_abc.Status, AbstractSet[str]] = {}
         server = util.FakeServerHost()
         server.trusted_usernames = 'bedevere-bot, miss-islington'
         cla = FakeCLAHost(problems)

--- a/ni/test/test_main.py
+++ b/ni/test/test_main.py
@@ -15,7 +15,7 @@ class FakeCLAHost(ni_abc.CLAHost):
     def __init__(self, problems=None):
         self._problems = problems
 
-    async def check(self, client, usernames):
+    async def problems(self, client, usernames):
         """Check if all of the specified usernames have signed the CLA."""
         self.usernames = usernames
         return self._problems


### PR DESCRIPTION
Update `check` and `update` to include in the message a list of users
that either didn't sign the CLA or haven't been found.

The implementation follows [@brettcannon's suggestion](https://github.com/python/the-knights-who-say-ni/issues/128#issuecomment-337313178)
to return a `Mapping[Status, AbstractSet[str]]` from `check` that is a
map of "problematic" statuses and their associated list of usernames.

See #128 