### PR TITLE
Make usernames for NO_USERNAME_BODY bpo-friendly

### DIFF
--- a/ni/github.py
+++ b/ni/github.py
@@ -229,7 +229,7 @@ class Host(ni_abc.ContribHost):
             problem_messages[status.name] = self._problem_message_template(
                 status
             ).format(
-                ', '.join(f"@{username}" for username in usernames)
+                ', '.join(f"**{username}**" for username in usernames)
             )
 
         message = NO_CLA_TEMPLATE.format_map(problem_messages)


### PR DESCRIPTION
When the bot posts a message for a PR author, there is a risk that the author will copy a username inside to their bpo profile settings as is, with initial `@`. As a result, the bot will not recognize/report an update hence creating confusion.

Since presence of `@` adds no value (the author gets a notification anyway), this commit safely turns this:

> We couldn't find a bugs.python.org (b.p.o) [...]:
>
> @username

into this:

> We couldn't find a bugs.python.org (b.p.o) [...]:
>
> **username**