### PR TITLE
Add useful links to the Knight's message

### DIFF
--- a/ni/github.py
+++ b/ni/github.py
@@ -36,6 +36,11 @@ contribution by verifying everyone involved has signed the \
 You can [check yourself](https://check-python-cla.herokuapp.com/) to see if the CLA has been received.
 
 Thanks again for the contribution, we look forward to reviewing it!
+
+If this is your first time contributing to cpython, you may find the following resources helpful:
+- A [guide to writing Pull Requests to CPython](https://devguide.python.org/pullrequest/)
+- A [guide to writing tests for CPython](https://devguide.python.org/runtests/)
+- A [guide to writing documentation for CPython](https://devguide.python.org/documenting/)
 """
 
 NO_CLA_BODY = """## CLA Missing


### PR DESCRIPTION
Those who are greeted by the Knight on GitHub are typically people contributing to CPython for the first time. Often, not having signed the CLA is symptomatic of the new contributor not having read any of the Developer's Guide, which may mean that there are other problems with their PR that make it difficult for it to be merged.

This PR proposes adding some helpful links to the Knight's message, pointing new contributors towards the Developer's Guide.