### PR TITLE
Change CLA missing to tell people to check themselves

### DIFF
--- a/ni/github.py
+++ b/ni/github.py
@@ -50,7 +50,8 @@ contribution. Please follow \
 to rectify this issue.
 
 If you have recently signed the CLA, please wait at least one business day
-before our records are updated.
+before our records are updated. After our records are updated, please
+[check your username](https://check-python-cla.herokuapp.com/)
 """
 
 NO_CLA_BODY_EASTEREGG = NO_CLA_BODY + """


### PR DESCRIPTION
CLA not signed tag is not automatically removed after records are updated, so add a line to tell people to check their username with the herokuapp link after they have signed the CLA. The better solution would be to automatically update CLA not signed tag after CLA signed record is in place, but that would mean a task has to be run automatically and that might be hard or cause security flaws or something. Easier to tell people to check themselves after they sign it.